### PR TITLE
Apollo spider support

### DIFF
--- a/master/CMakeLists.txt
+++ b/master/CMakeLists.txt
@@ -147,26 +147,22 @@ endif ()
 # *******************************************
 # *********** APOLLO LIBRARY ****************
 # *******************************************
+#set(SKIP_APOLLO 1)
+if (${SKIP_APOLLO})
+    MESSAGE("Skipping APOLLO")
+else ()
+    find_package(APOLLO)
+endif ()
 
-set(USEAPOLLO 1)
-
-if(${USEAPOLLO})
-	#MESSAGE("Looking for APOLLO libraries")
-	find_library(apollo_LIBRARY LLVMApollo)
-	find_library(apolloRuntime_LIBRARY apolloRuntime)
-	#MESSAGE(${apollo_LIBRARY})
-	#MESSAGE(${apolloRuntime_LIBRARY})
-	if(apollo_LIBRARY AND apolloRuntime_LIBRARY)
-		MESSAGE("")
-		MESSAGE("WARNING: Using APOLLO compiler")
-		MESSAGE("If you do not wish to use APOLLO, please deactivate USEAPOLLO in CMakeLists.txt")
-		MESSAGE("")
-		add_definitions(-DAPOLLO_AVAILABLE)
-	else()
-		set(USEAPOLLO 0)
-	endif()
-	
+if(APOLLO_FOUND)
+	add_definitions(-DAPOLLO_AVAILABLE)
+else()
+	MESSAGE("WARNING: Couldn't find APOLLO libraries")
+	set(APOLLO_LIBRARIES "")
+	set(APOLLO_INCLUDE_DIRS "")
 endif()
+	
+
 
 # *******************************************
 # *************  spider.dll/a  **************
@@ -175,6 +171,7 @@ endif()
 include_directories(
         #${THREADS_PTHREADS_INCLUDE_DIR}
         ${PAPI_INCLUDE_DIRS}
+	${APOLLO_INCLUDE_DIRS}
         ${PTHREADDIR}/include
         ${STDTHREADDIR}
         ./libspider/
@@ -234,7 +231,7 @@ file(
 
 
 add_library(Spider SHARED ${source_files} ${header_files} ${papify_sources})
-target_link_libraries(Spider ${CMAKE_THREAD_LIBS_INIT} ${PAPI_LIBRARIES})
+target_link_libraries(Spider ${CMAKE_THREAD_LIBS_INIT} ${PAPI_LIBRARIES} ${APOLLO_LIBRARIES})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
 

--- a/master/CMakeLists.txt
+++ b/master/CMakeLists.txt
@@ -144,6 +144,29 @@ else ()
     set(PAPI_INCLUDE_DIRS "")
 endif ()
 
+# *******************************************
+# *********** APOLLO LIBRARY ****************
+# *******************************************
+
+set(USEAPOLLO 1)
+
+if(${USEAPOLLO})
+	#MESSAGE("Looking for APOLLO libraries")
+	find_library(apollo_LIBRARY LLVMApollo)
+	find_library(apolloRuntime_LIBRARY apolloRuntime)
+	#MESSAGE(${apollo_LIBRARY})
+	#MESSAGE(${apolloRuntime_LIBRARY})
+	if(apollo_LIBRARY AND apolloRuntime_LIBRARY)
+		MESSAGE("")
+		MESSAGE("WARNING: Using APOLLO compiler")
+		MESSAGE("If you do not wish to use APOLLO, please deactivate USEAPOLLO in CMakeLists.txt")
+		MESSAGE("")
+		add_definitions(-DAPOLLO_AVAILABLE)
+	else()
+		set(USEAPOLLO 0)
+	endif()
+	
+endif()
 
 # *******************************************
 # *************  spider.dll/a  **************

--- a/master/lib/cmake_modules/FindAPOLLO.cmake
+++ b/master/lib/cmake_modules/FindAPOLLO.cmake
@@ -1,0 +1,44 @@
+# Try to find APOLLO headers and libraries.
+#
+# Usage of this module as follows:
+#
+#     find_package(APOLLO)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  APOLLO_PREFIX       Set this variable to the root installation of
+#                      libapolloRuntime if the module has problems finding the
+#                      proper installation path.
+#
+# Variables defined by this module:
+#
+#  APOLLO_FOUND              System has APOLLO libraries and headers
+#  APOLLO_LIBRARIES          The APOLLO library
+#  APOLLO_INCLUDE_DIRS       The location of APOLLO headers
+
+find_path(APOLLO_PREFIX
+    NAMES include/apolloAPI.h
+)
+
+find_library(APOLLO_LIBRARIES
+    NAMES libapolloRuntime.so apolloRuntime
+    HINTS ${APOLLO_PREFIX}/lib ${HILTIDEPS}/lib
+)
+
+find_path(APOLLO_INCLUDE_DIRS
+    NAMES apolloAPI.h
+    HINTS ${APOLLO_PREFIX}/include ${HILTIDEPS}/include
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(APOLLO DEFAULT_MSG
+    APOLLO_LIBRARIES
+    APOLLO_INCLUDE_DIRS
+)
+
+mark_as_advanced(
+    APOLLO_PREFIX_DIRS
+    APOLLO_LIBRARIES
+    APOLLO_INCLUDE_DIRS
+)

--- a/master/libspider/lrt/lrt.cpp
+++ b/master/libspider/lrt/lrt.cpp
@@ -78,6 +78,7 @@ LRT::LRT(int ix) {
     usePapify_ = false;
     dumpPapifyInfo_ = false;
     feedbackPapifyInfo_ = false;
+    useApollo_ = false;
 
     traceEnabled_ = false;
     repeatJobQueue_ = false;
@@ -286,6 +287,11 @@ void LRT::runJob(JobInfoMessage *job) {
     if (job->specialActor_ && fctID < 6) {
         specialActors[fctID](inFifosAlloc, outFifosAlloc, inParams, outParams); // compute
     } else if (fctID < nFct_) {
+        #ifdef APOLLO_AVAILABLE
+            if(useApollo_){
+                apolloAddJobIdx(job->srdagID_, pthread_self());
+            }
+        #endif
         if (usePapify_) {
 #ifdef PAPI_AVAILABLE
             // TODO, find better way to do that

--- a/master/libspider/lrt/lrt.h
+++ b/master/libspider/lrt/lrt.h
@@ -48,6 +48,12 @@
 #include <LrtCommunicator.h>
 #include <scheduling/PiSDFScheduleJob.h>
 
+#ifdef APOLLO_AVAILABLE
+
+#include <apolloAPI.h>
+
+#endif
+
 #ifdef PAPI_AVAILABLE
 
 #include "../papify/PapifyAction.h"
@@ -96,6 +102,8 @@ public:
 
     inline void setPapifyFeedback();
 
+    inline void setUseApollo();
+
     inline void setCommunicators();
 
 #ifdef PAPI_AVAILABLE
@@ -121,6 +129,7 @@ private:
     bool usePapify_;
     bool dumpPapifyInfo_;
     bool feedbackPapifyInfo_;
+    bool useApollo_;
     int jobIx_;
     int jobIxTotal_;
     Stack *lrtStack_;
@@ -258,6 +267,10 @@ inline void LRT::setPapifyDump() {
 
 inline void LRT::setPapifyFeedback() {
     feedbackPapifyInfo_ = true;
+}
+
+inline void LRT::setUseApollo() {
+    useApollo_ = true;
 }
 
 void LRT::initStack(StackInfo info) {

--- a/master/libspider/platforms/platform_pthread/platformPThread.cpp
+++ b/master/libspider/platforms/platform_pthread/platformPThread.cpp
@@ -298,10 +298,14 @@ PlatformPThread::PlatformPThread(SpiderConfig &config, SpiderStackConfig &stackC
 #endif
 
 #ifndef APOLLO_AVAILABLE
-    if (config.apolloEnabled) {
+    if(config.apolloCompiled){
+        printf("WARNING: Spider was not compiled on a platform_ with APOLLO.\n");
+        printf("Please, recompile Spider with APOLLO or disable APOLLO in the CMakeLists.txt of the application.\n");
+        exit(0);
+    }else if (config.apolloEnabled) {
         printf("WARNING: Spider was not compiled using Apollo optimizations, thus it is disabled.\n");
+        config.apolloEnabled = false;
     }
-    config.apolloEnabled = false;
 #endif
 
     /** Filling up parameters for each threads */

--- a/master/libspider/platforms/platform_pthread/platformPThread.cpp
+++ b/master/libspider/platforms/platform_pthread/platformPThread.cpp
@@ -161,6 +161,13 @@ void *lrtPthreadRunner(void *args) {
         }
     }
 #endif
+
+#ifdef APOLLO_AVAILABLE
+    /** Enable APOLLO if needed to */
+    if (lrtInfo->useApollo) {
+        lrtInfo->lrt->setUseApollo();
+    }
+#endif
     /** Wait for all LRTs to be created */
     pthread_barrier_wait(lrtInfo->pthreadBarrier);
     /** Run LRT */
@@ -290,6 +297,13 @@ PlatformPThread::PlatformPThread(SpiderConfig &config, SpiderStackConfig &stackC
     }
 #endif
 
+#ifndef APOLLO_AVAILABLE
+    if (config.apolloEnabled) {
+        printf("WARNING: Spider was not compiled using Apollo optimizations, thus it is disabled.\n");
+    }
+    config.apolloEnabled = false;
+#endif
+
     /** Filling up parameters for each threads */
     pthread_barrier_init(&pthreadLRTBarrier, nullptr, nLrt_);
     for (std::uint32_t i = 0; i < archi->getNPE(); i++) {
@@ -317,6 +331,8 @@ PlatformPThread::PlatformPThread(SpiderConfig &config, SpiderStackConfig &stackC
         lrtInfoArray_[i].usePapify = config.usePapify;
         lrtInfoArray_[i].dumpPapifyInfo = config.dumpPapifyInfo;
         lrtInfoArray_[i].feedbackPapifyInfo = config.feedbackPapifyInfo;
+        /**Apollo related information */
+        lrtInfoArray_[i].useApollo = config.apolloEnabled;
     }
     auto spiderGRTID = archi->getSpiderGRTID();
     lrtThreadsArray[spiderGRTID] = pthread_self();
@@ -363,6 +379,12 @@ PlatformPThread::PlatformPThread(SpiderConfig &config, SpiderStackConfig &stackC
     }
 
 
+#endif
+
+#ifdef APOLLO_AVAILABLE
+    if (config.apolloEnabled) {
+        lrt_[spiderGRTID]->setUseApollo();
+    }
 #endif
 
     // Wait for all LRTs to be ready to start

--- a/master/libspider/spider/platformPThread.h
+++ b/master/libspider/spider/platformPThread.h
@@ -218,6 +218,7 @@ typedef struct LRTInfo {
     bool usePapify;
     bool dumpPapifyInfo;
     bool feedbackPapifyInfo;
+    bool useApollo;
     StackInfo lrtStack;
     PlatformPThread *platform;
     pthread_barrier_t *pthreadBarrier;

--- a/master/libspider/spider/spider.cpp
+++ b/master/libspider/spider/spider.cpp
@@ -97,6 +97,7 @@ static bool useGraphOptim_;
 static bool useActorPrecedence_;
 static bool traceEnabled_;
 static bool papifyFeedbackEnabled_;
+static bool apolloEnabled_;
 
 static bool containsDynamicParam(PiSDFGraph *const graph) {
     for (int i = 0; i < graph->getNParam(); ++i) {
@@ -138,6 +139,7 @@ void Spider::init(SpiderConfig &cfg, SpiderStackConfig &stackConfig) {
 
     setVerbose(cfg.verbose);
     setTraceEnabled(cfg.traceEnabled);
+    setApolloEnabled(cfg.apolloEnabled);
 
     //TODO: add a switch between the different platform
     platform_ = new PlatformPThread(cfg, stackConfig);
@@ -147,6 +149,13 @@ void Spider::init(SpiderConfig &cfg, SpiderStackConfig &stackConfig) {
     if (traceEnabled_) {
         Launcher::get()->sendEnableTrace(-1);
     }
+    #ifdef APOLLO_AVAILABLE
+        if (apolloEnabled_) {
+            initApolloForDataflow();
+        }else{
+            disableApollo();
+        }
+    #endif
 //    Logger::enable(LOG_JOB);
 }
 
@@ -297,6 +306,10 @@ void Spider::setPapifyFeedbackEnabled(bool papifyFeedbackEnabled) {
     papifyFeedbackEnabled_ = papifyFeedbackEnabled;
 }
 
+void Spider::setApolloEnabled(bool apolloEnabled) {
+    apolloEnabled_ = apolloEnabled;
+}
+
 bool Spider::getVerbose() {
     return verbose_;
 }
@@ -311,6 +324,10 @@ bool Spider::getActorPrecedence() {
 
 bool Spider::getTraceEnabled() {
     return traceEnabled_;
+}
+
+bool Spider::getApolloEnabled() {
+    return apolloEnabled_;
 }
 
 void Spider::setArchi(Archi *archi) {

--- a/master/libspider/spider/spider.cpp
+++ b/master/libspider/spider/spider.cpp
@@ -98,6 +98,7 @@ static bool useActorPrecedence_;
 static bool traceEnabled_;
 static bool papifyFeedbackEnabled_;
 static bool apolloEnabled_;
+static bool apolloCompiled_;
 
 static bool containsDynamicParam(PiSDFGraph *const graph) {
     for (int i = 0; i < graph->getNParam(); ++i) {
@@ -140,6 +141,7 @@ void Spider::init(SpiderConfig &cfg, SpiderStackConfig &stackConfig) {
     setVerbose(cfg.verbose);
     setTraceEnabled(cfg.traceEnabled);
     setApolloEnabled(cfg.apolloEnabled);
+    setApolloCompiled(cfg.apolloCompiled);
 
     //TODO: add a switch between the different platform
     platform_ = new PlatformPThread(cfg, stackConfig);
@@ -150,9 +152,9 @@ void Spider::init(SpiderConfig &cfg, SpiderStackConfig &stackConfig) {
         Launcher::get()->sendEnableTrace(-1);
     }
     #ifdef APOLLO_AVAILABLE
-        if (apolloEnabled_) {
+        if (apolloEnabled_ && apolloCompiled_) {
             initApolloForDataflow();
-        }else{
+        }else if(apolloCompiled_){
             disableApollo();
         }
     #endif
@@ -310,6 +312,10 @@ void Spider::setApolloEnabled(bool apolloEnabled) {
     apolloEnabled_ = apolloEnabled;
 }
 
+void Spider::setApolloCompiled(bool apolloCompiled){
+    apolloCompiled_ = apolloCompiled;
+}
+
 bool Spider::getVerbose() {
     return verbose_;
 }
@@ -328,6 +334,10 @@ bool Spider::getTraceEnabled() {
 
 bool Spider::getApolloEnabled() {
     return apolloEnabled_;
+}
+
+bool Spider::getApolloCompiled() {
+    return apolloCompiled_;
 }
 
 void Spider::setArchi(Archi *archi) {

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -45,8 +45,6 @@
 #include <spider-api/user/archi.h>
 #include <spider-api/user/graph.h>
 
-#define APOLLO_AVAILABLE
-
 #ifdef APOLLO_AVAILABLE
 
 #include <apolloAPI.h>

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -45,6 +45,14 @@
 #include <spider-api/user/archi.h>
 #include <spider-api/user/graph.h>
 
+#define APOLLO_AVAILABLE
+
+#ifdef APOLLO_AVAILABLE
+
+#include <apolloAPI.h>
+
+#endif
+
 #define MAX_STATS_VERTICES 1000
 #define MAX_STATS_PE_TYPES 3
 
@@ -122,6 +130,7 @@ typedef struct SpiderConfig {
     bool usePapify;
     bool dumpPapifyInfo;
     bool feedbackPapifyInfo;
+    bool apolloEnabled;
 
     std::map<lrtFct, std::map<const char *, PapifyConfig*>> papifyJobInfo;
     std::map<lrtFct, std::map<const char *, std::map<int, double>>> energyModelsInfo;
@@ -185,6 +194,8 @@ namespace Spider {
 
     void setPapifyFeedbackEnabled(bool papifyFeedbackEnabled);
 
+    void setApolloEnabled(bool apolloEnabled);
+
     bool getVerbose();
 
     bool getGraphOptim();
@@ -192,6 +203,8 @@ namespace Spider {
     bool getActorPrecedence();
 
     bool getTraceEnabled();
+
+    bool getApolloEnabled();
 
     void setArchi(Archi *archi);
 

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -129,6 +129,7 @@ typedef struct SpiderConfig {
     bool dumpPapifyInfo;
     bool feedbackPapifyInfo;
     bool apolloEnabled;
+    bool apolloCompiled;
 
     std::map<lrtFct, std::map<const char *, PapifyConfig*>> papifyJobInfo;
     std::map<lrtFct, std::map<const char *, std::map<int, double>>> energyModelsInfo;
@@ -194,6 +195,8 @@ namespace Spider {
 
     void setApolloEnabled(bool apolloEnabled);
 
+    void setApolloCompiled(bool apollloCompiled);
+
     bool getVerbose();
 
     bool getGraphOptim();
@@ -203,6 +206,8 @@ namespace Spider {
     bool getTraceEnabled();
 
     bool getApolloEnabled();
+
+    bool getApolloCompiled();
 
     void setArchi(Archi *archi);
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,7 +5,8 @@ Spider Changelog
 *XXXX.XX.XX*
 
 ### New Feature
-
+* SPiDER now supports Apollo optimizations
+  * Apollo can be skipped with SKIP_APOLLO in CMakeLists.txt
 ### Changes
 
 ### Bug fix


### PR DESCRIPTION
Spider now supports Apollo optimizations. They can be deactivated through SKIP_APOLLO in CMakeLists.txt. This branch should be merged together with apolloPreesmSupport in PREESM repository.