### PR TITLE
Energy hacking mapping spider

### DIFF
--- a/master/CMakeLists.txt
+++ b/master/CMakeLists.txt
@@ -202,6 +202,7 @@ file(
         ./libspider/spider/scheduling/*.cpp
         ./libspider/spider/scheduling/MemAlloc/*.cpp
         ./libspider/spider/scheduling/Scheduler/*.cpp
+        ./libspider/spider/energyAwareness/*.cpp
 )
 
 file(
@@ -227,6 +228,7 @@ file(
         ./libspider/spider/scheduling/*.h
         ./libspider/spider/scheduling/MemAlloc/*.h
         ./libspider/spider/scheduling/Scheduler/*.h
+        ./libspider/spider/energyAwareness/*.h
 )
 
 

--- a/master/libspider/spider/energyAwareness/energyAwareness.cpp
+++ b/master/libspider/spider/energyAwareness/energyAwareness.cpp
@@ -1,0 +1,334 @@
+/**
+ * Copyright or © or Copr. IETR/INSA - Rennes (2013 - 2019) :
+ *
+ * Antoine Morvan <antoine.morvan@insa-rennes.fr> (2018 - 2019)
+ * Clément Guy <clement.guy@insa-rennes.fr> (2014)
+ * Daniel Madroñal <daniel.madronal@upm.es> (2019)
+ * Florian Arrestier <florian.arrestier@insa-rennes.fr> (2018 - 2019)
+ * Hugo Miomandre <hugo.miomandre@insa-rennes.fr> (2017)
+ * Julien Heulot <julien.heulot@insa-rennes.fr> (2013 - 2018)
+ * rlazcano <raquel.lazcano@upm.es> (2019)
+ * Yaset Oliva <yaset.oliva@insa-rennes.fr> (2013 - 2014)
+ *
+ * Spider is a dataflow based runtime used to execute dynamic PiSDF
+ * applications. The Preesm tool may be used to design PiSDF applications.
+ *
+ * This software is governed by the CeCILL  license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL license and that you accept its terms.
+ */
+#include <cinttypes>
+#include "energyAwareness.h"
+#include <algorithm>
+#include <graphs/SRDAG/SRDAGGraph.h>
+#include <limits>
+#include <math.h>
+
+#include "spider.h"
+
+#ifdef __k1__
+#define CHIP_FREQ ((float)(__bsp_frequency)/(1000*1000))
+#endif
+#ifndef CHIP_FREQ
+#define CHIP_FREQ (1)
+#endif
+
+// energy awareness info
+static Time startingExecutionTime_;
+static Time endingExecutionTime_;
+
+static std::map<std::uint32_t, std::vector<std::uint32_t>> peIdPerPeType_; 
+static std::map<std::uint32_t, std::uint32_t> pesBeingDisabled_; 
+
+static std::map<const char*, Param> dynamicParameters_;
+static std::vector<std::map<std::uint32_t, std::uint32_t>> configsAlreadyUsed_; 
+static std::map<std::uint32_t, std::uint32_t> pesBestConfig_; 
+static double bestEnergy_;
+static double bestObjective_;
+static bool energyAlreadyOptimized_;
+static bool solutionShown_;
+static bool aboveBelowObjective_; // 1 current config is above objective -- 0 current config is below objective
+static std::uint32_t timesObjectiveMissed_; // Fail safe when not reaching the objective
+static bool forcedUpdate_; // True when the performance of the best config does not reach the objective 10 times in a row
+
+static std::map<std::map<const char*, Param>, std::vector<std::map<std::uint32_t, std::uint32_t>>> configsAlreadyUsedBackup_; 
+static std::map<std::map<const char*, Param>, std::map<std::uint32_t, std::uint32_t>> pesBestConfigBackup_; 
+static std::map<std::map<const char*, Param>, std::map<std::uint32_t, std::uint32_t>> pesBeingDisabledBackup_; 
+static std::map<std::map<const char*, Param>, double> bestEnergyBackup_; 
+static std::map<std::map<const char*, Param>, double> bestObjectiveBackup_; 
+static std::map<std::map<const char*, Param>, bool> energyAlreadyOptimizedBackup_; 
+static std::map<std::map<const char*, Param>, bool> aboveBelowObjectiveBackup_; 
+
+void EnergyAwareness::setStartingTime() {
+    startingExecutionTime_ = Platform::get()->getTime();
+}
+
+void EnergyAwareness::setEndTime() {
+    endingExecutionTime_ = Platform::get()->getTime();
+}
+
+unsigned long EnergyAwareness::getExecutionTime() {
+    return (endingExecutionTime_ - startingExecutionTime_) / CHIP_FREQ;
+}
+
+double EnergyAwareness::computeEnergy(SRDAGGraph *srdag, Archi *archi, double fpsEstimation) {
+    double energyIter = 0.0;
+    std::vector<std::uint32_t> pesUsed;
+    for (int i = 0; i < srdag->getNVertex(); i++) {
+        SRDAGVertex *vertex = srdag->getVertex(i);
+        if (vertex->getType() == SRDAG_NORMAL) {
+            int peUsed = vertex->getScheduleJob()->getMappedPE();
+            int peType = archi->getPEFromSpiderID(peUsed)->getHardwareType();
+            auto piVertex = vertex->getReference();
+            double energy = piVertex->getEnergyOnPEType(peType);
+            energyIter = energyIter + energy;      
+        }
+    }
+    // we asume that energy for each actor is given in uJ
+    double energyApp = (energyIter / (1000.0 * 1000.0))  * fpsEstimation;
+    // as power is provided in W and we want energy per second, values are equivalent
+    double energyPlatform = archi->getBasePower();
+    for (unsigned int i = 0; i < archi->getNPE(); i++) {
+        auto pe = archi->getPEFromSpiderID(i);
+        if (pe->isEnabled()) {
+            energyPlatform = energyPlatform + pe->getPower();            
+        }
+    }
+    return energyApp + energyPlatform;    
+}
+
+double EnergyAwareness::computeFps() {
+    unsigned long execTime = EnergyAwareness::getExecutionTime();
+    // execution time is given in ns
+    return (1000.0 * 1000.0 * 1000.0) / (double) execTime;
+}
+
+void EnergyAwareness::setUp(Archi *archi) {
+    auto spiderId = archi->getSpiderGRTID();
+    for (std::uint32_t i = 0; i < archi->getNPE(); i++) {
+        auto pe = archi->getPEFromSpiderID(i);
+        if (i != spiderId) {
+            auto peType = pe->getHardwareType();
+            auto it = peIdPerPeType_.find(peType);
+            if (it != peIdPerPeType_.end()) {
+                it->second.push_back(i);
+            } else {
+                std::vector<std::uint32_t> peIdSet;
+                peIdSet.push_back(i);
+                peIdPerPeType_.insert(std::make_pair(peType, peIdSet));
+            }          
+        }
+    }
+    for (auto it = peIdPerPeType_.begin(); it != peIdPerPeType_.end(); it++) {
+        pesBeingDisabled_.insert(std::make_pair(it->first, 0));
+        pesBestConfig_.insert(std::make_pair(it->first, 0));
+    }
+    energyAlreadyOptimized_ = false;
+    solutionShown_ = false;
+    bestEnergy_ = std::numeric_limits<double>::max();
+    bestObjective_ = 0.0;
+    timesObjectiveMissed_ = 0;
+    forcedUpdate_ = false;
+}
+
+void EnergyAwareness::checkExecutionPerformance(double fpsEstimation, double energyConsumed) {
+    aboveBelowObjective_ = false;
+    if (fpsEstimation >= Spider::getPerformanceObjective()) {
+        aboveBelowObjective_ = true;
+        if (bestEnergy_ > energyConsumed || forcedUpdate_) {
+            bestEnergy_ = energyConsumed;
+            bestObjective_ = fpsEstimation;
+            for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
+                pesBestConfig_[it->first] = it->second;
+            }
+        } 
+    }else if (fpsEstimation > bestObjective_ && bestEnergy_ == std::numeric_limits<double>::max()) {
+        bestObjective_ = fpsEstimation;
+        for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
+            pesBestConfig_[it->first] = it->second;
+        }
+    }
+    forcedUpdate_ = false;
+}
+
+bool EnergyAwareness::generateNextConfiguration() {
+    return generateNextFineGrainConfiguration();
+}
+
+bool EnergyAwareness::generateNextFineGrainConfiguration(){
+    bool alreadyUsingTheMaximum = true;
+    for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
+        if(aboveBelowObjective_){ // As we are modifying the number of disabled PEs, we have to increase the disable PEs when we are above the number
+            if(pesBeingDisabled_[it->first] == peIdPerPeType_[it->first].size()){
+                pesBeingDisabled_[it->first] = 0;
+            }else{
+                pesBeingDisabled_[it->first] = pesBeingDisabled_[it->first] + 1; 
+                break;
+            }      
+        } else {
+            if(pesBeingDisabled_[it->first] == 0){
+                pesBeingDisabled_[it->first] = peIdPerPeType_[it->first].size();
+            }else{
+                pesBeingDisabled_[it->first] = pesBeingDisabled_[it->first] - 1;  
+                alreadyUsingTheMaximum = false;
+                break;
+            }      
+        }
+    }
+    auto it = std::find(configsAlreadyUsed_.begin(), configsAlreadyUsed_.end(), pesBeingDisabled_);
+    if (it == configsAlreadyUsed_.end()) {
+        return true;
+    } else if(!aboveBelowObjective_ && bestEnergy_ != std::numeric_limits<double>::max() && !alreadyUsingTheMaximum){
+        timesObjectiveMissed_++;
+        if(timesObjectiveMissed_ == 10){
+            timesObjectiveMissed_ = 0;
+            forcedUpdate_ = true;
+            printf("Increasing number of enabled PEs because the objective has been missed 10 times\n");
+            return true;
+        }
+    }
+    return false;
+}
+
+void EnergyAwareness::applyConfig(Archi *archi){
+    auto it = std::find(configsAlreadyUsed_.begin(), configsAlreadyUsed_.end(), pesBeingDisabled_);
+    if (it == configsAlreadyUsed_.end()) {
+        configsAlreadyUsed_.push_back(pesBeingDisabled_);
+    }
+    std::map<std::uint32_t, std::uint32_t> pesAlreadyDisbled;
+    for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
+        pesAlreadyDisbled.insert(std::make_pair(it->first, 0));
+    }
+    for(auto it = peIdPerPeType_.begin(); it != peIdPerPeType_.end(); it++){
+        for(auto itInner = it->second.begin(); itInner != it->second.end(); itInner++){
+            archi->activatePE(archi->getPEFromSpiderID(*itInner));
+        }
+    }
+    for(auto it = peIdPerPeType_.begin(); it != peIdPerPeType_.end(); it++){
+        for(auto itInner = it->second.begin(); itInner != it->second.end(); itInner++){
+            if(pesAlreadyDisbled[it->first] == pesBeingDisabled_[it->first]){
+                break;
+            }
+            archi->deactivatePE(archi->getPEFromSpiderID(*itInner));
+            pesAlreadyDisbled[it->first] = pesAlreadyDisbled[it->first] + 1;
+        }
+    }
+}
+
+void EnergyAwareness::analyzeExecution(SRDAGGraph *srdag, Archi *archi){
+    double fpsEstimation = computeFps();
+    double energyConsumed = computeEnergy(srdag, archi, fpsEstimation);
+
+    checkExecutionPerformance(fpsEstimation, energyConsumed);
+}
+
+void EnergyAwareness::prepareNextExecution(){
+    if(!generateNextConfiguration()){
+        energyAlreadyOptimized_ = true;
+        pesBeingDisabled_ = pesBestConfig_;
+        for (auto it = pesBestConfig_.begin(); it != pesBestConfig_.end(); it++) {
+            pesBeingDisabled_[it->first] = it->second;
+        }
+        if(!solutionShown_){
+            solutionShown_ = true;
+            std::uint32_t totalCoresUsed = 0;
+            for (auto it = pesBestConfig_.begin(); it != pesBestConfig_.end(); it++) {
+                totalCoresUsed = totalCoresUsed + peIdPerPeType_[it->first].size() - it->second;
+            }
+            if(bestEnergy_ == std::numeric_limits<double>::max()){
+                printf("Best FPS %f. Objective not reachable --> ", bestObjective_);    
+                printf("Closer one reached using %d cores", (totalCoresUsed + 1)); // We include here the GRT
+            }else{
+                printf("Best FPS %f and best energy consumed = %f ---> ", bestObjective_, bestEnergy_);   
+                printf("Reached using %d cores", (totalCoresUsed + 1)); // We include here the GRT             
+            }
+            printf("\n");
+            printf("Using config (PEType: disabled/total): ");
+            for (auto it = pesBestConfig_.begin(); it != pesBestConfig_.end(); it++) {
+                printf("%d: %d/%lu --- ", it->first, it->second, peIdPerPeType_[it->first].size());
+            }
+            printf("\n");
+        }
+    }
+}
+
+void EnergyAwareness::recoverConfigOrDefault() {
+    timesObjectiveMissed_ = 0;
+    // All the energy-awareness related variables are stored at the same time
+    // So we only check one and we consider that everything is properly done
+    auto itCheckerEnergyAlreadyOptimized = energyAlreadyOptimizedBackup_.find(dynamicParameters_);
+    if(itCheckerEnergyAlreadyOptimized != energyAlreadyOptimizedBackup_.end()){
+        energyAlreadyOptimized_ = energyAlreadyOptimizedBackup_[dynamicParameters_];
+        aboveBelowObjective_ = aboveBelowObjectiveBackup_[dynamicParameters_];
+        pesBestConfig_ = pesBestConfigBackup_[dynamicParameters_];
+        pesBeingDisabled_ = pesBeingDisabledBackup_[dynamicParameters_]; 
+        bestEnergy_ = bestEnergyBackup_[dynamicParameters_];
+        bestObjective_ = bestObjectiveBackup_[dynamicParameters_];
+        configsAlreadyUsed_ = configsAlreadyUsedBackup_[dynamicParameters_];
+    }else{
+        energyAlreadyOptimized_ = false;        
+        for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
+            pesBestConfig_[it->first] = it->second;
+        }
+        bestEnergy_ = std::numeric_limits<double>::max();
+        bestObjective_ = 0.0;
+        configsAlreadyUsed_.clear();
+    }
+    solutionShown_ = false;
+}
+
+void EnergyAwareness::setNewDynamicParams(std::map<const char*, Param> dynamicParamsMap) {
+    //Store current best ones
+    configsAlreadyUsedBackup_[dynamicParameters_] = configsAlreadyUsed_; 
+    pesBestConfigBackup_[dynamicParameters_] = pesBestConfig_; 
+    pesBeingDisabledBackup_[dynamicParameters_] = pesBeingDisabled_; 
+    bestEnergyBackup_[dynamicParameters_] = bestEnergy_; 
+    bestObjectiveBackup_[dynamicParameters_] = bestObjective_; 
+    energyAlreadyOptimizedBackup_[dynamicParameters_] = energyAlreadyOptimized_;
+    aboveBelowObjectiveBackup_[dynamicParameters_] = aboveBelowObjective_;
+
+    //Check the need to update the config
+    bool dirtyEnergyConfig = false;
+    for (auto it = dynamicParamsMap.begin(); it != dynamicParamsMap.end(); it++) {
+        auto itChecker = dynamicParameters_.find(it->first);
+        if(itChecker == dynamicParameters_.end()){
+            dynamicParameters_.insert(std::make_pair(it->first, it->second));
+            dirtyEnergyConfig = true;
+        } else {
+            if(dynamicParameters_[it->first] != it->second){
+                dirtyEnergyConfig = true;
+                dynamicParameters_[it->first] = it->second;
+            }
+        }        
+    }
+    //Update config if needed
+    if(dirtyEnergyConfig){
+        recoverConfigOrDefault();
+    }
+}
+
+bool EnergyAwareness::getEnergyAlreadyOptimized(){
+    return energyAlreadyOptimized_;
+}

--- a/master/libspider/spider/energyAwareness/energyAwareness.h
+++ b/master/libspider/spider/energyAwareness/energyAwareness.h
@@ -84,6 +84,8 @@ namespace EnergyAwareness {
 
     bool generateNextFineGrainConfiguration();
 
+    bool generateNextCoarseGrainConfiguration();
+
     bool getEnergyAlreadyOptimized();
 }
 

--- a/master/libspider/spider/energyAwareness/energyAwareness.h
+++ b/master/libspider/spider/energyAwareness/energyAwareness.h
@@ -1,0 +1,90 @@
+/**
+ * Copyright or © or Copr. IETR/INSA - Rennes (2014 - 2019) :
+ *
+ * Antoine Morvan <antoine.morvan@insa-rennes.fr> (2018 - 2019)
+ * Daniel Madroñal <daniel.madronal@upm.es> (2019)
+ * Florian Arrestier <florian.arrestier@insa-rennes.fr> (2018 - 2019)
+ * Hugo Miomandre <hugo.miomandre@insa-rennes.fr> (2017)
+ * Julien Heulot <julien.heulot@insa-rennes.fr> (2014 - 2018)
+ * rlazcano <raquel.lazcano@upm.es> (2019)
+ *
+ * Spider is a dataflow based runtime used to execute dynamic PiSDF
+ * applications. The Preesm tool may be used to design PiSDF applications.
+ *
+ * This software is governed by the CeCILL  license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL license and that you accept its terms.
+ */
+#ifndef ENERGYAWARENESS_H
+#define ENERGYAWARENESS_H
+
+#include <map>
+#include <vector>
+#include <cstdint>
+#include <spider-api/user/archi.h>
+#include <spider-api/user/graph.h>
+
+
+/* === Type(s) === */
+
+using Time = std::uint64_t;
+using Param = std::int64_t;
+
+namespace EnergyAwareness {
+
+    // Energy-awareness functions
+
+    double computeEnergy(SRDAGGraph *srdag, Archi *archi, double fpsEstimation);
+
+    double computeFps();
+
+    void setStartingTime();
+
+    void setEndTime();
+
+    unsigned long getExecutionTime();
+
+    void setUp(Archi *archi);
+
+    void checkExecutionPerformance(double fpsEstimation, double energyConsumed);
+
+    bool generateNextConfiguration();
+
+    void applyConfig(Archi *archi);
+
+    void analyzeExecution(SRDAGGraph *srdag, Archi *archi);
+
+    void prepareNextExecution();
+
+    void recoverConfigOrDefault();
+
+    void setNewDynamicParams(std::map<const char*, Param> dynamicParamsMap);
+
+    bool generateNextFineGrainConfiguration();
+
+    bool getEnergyAlreadyOptimized();
+}
+
+#endif//ENERGYAWARENESS_H

--- a/master/libspider/spider/graphTransfo/GraphTransfo.cpp
+++ b/master/libspider/spider/graphTransfo/GraphTransfo.cpp
@@ -221,6 +221,10 @@ void jit_ms(
             fprintf(stderr, "INFO: Resolved parameters.\n");
         }
 
+        if(Spider::getEnergyAwareness()){
+            Spider::energyAwarenessApplyConfig();            
+        }
+
         TimeMonitor::startMonitoring();
 
         while (!jobQueue.isEmpty()) {

--- a/master/libspider/spider/graphTransfo/GraphTransfo.cpp
+++ b/master/libspider/spider/graphTransfo/GraphTransfo.cpp
@@ -301,7 +301,9 @@ void jit_ms(
     scheduler->schedule(topSrdag, memAlloc, schedule, archi);
     TimeMonitor::endMonitoring(TRACE_SPIDER_SCHED);
     /** Run the schedule **/
+    Spider::setStartingTime();
     schedule->executeAndRun();
+    Spider::setEndTime();
     schedule->~SRDAGSchedule();
     StackMonitor::free(TRANSFO_STACK, schedule);
 }

--- a/master/libspider/spider/graphTransfo/GraphTransfo.cpp
+++ b/master/libspider/spider/graphTransfo/GraphTransfo.cpp
@@ -53,6 +53,8 @@
 #include <scheduling/Scheduler/SRDAGLessScheduler.h>
 #include <scheduling/Scheduler/SRDAGLessListScheduler.h>
 
+#include "energyAwareness/energyAwareness.h"
+
 #define SCHEDULE_SIZE 20000
 
 static void initJob(transfoJob *job, SRDAGVertex *nextHierVx) {
@@ -222,7 +224,7 @@ void jit_ms(
         }
 
         if(Spider::getEnergyAwareness()){
-            Spider::energyAwarenessApplyConfig();            
+            EnergyAwareness::applyConfig(archi);            
         }
 
         TimeMonitor::startMonitoring();
@@ -305,9 +307,9 @@ void jit_ms(
     scheduler->schedule(topSrdag, memAlloc, schedule, archi);
     TimeMonitor::endMonitoring(TRACE_SPIDER_SCHED);
     /** Run the schedule **/
-    Spider::setStartingTime();
+    EnergyAwareness::setStartingTime();
     schedule->executeAndRun();
-    Spider::setEndTime();
+    EnergyAwareness::setEndTime();
     schedule->~SRDAGSchedule();
     StackMonitor::free(TRANSFO_STACK, schedule);
 }

--- a/master/libspider/spider/launcher/Launcher.cpp
+++ b/master/libspider/spider/launcher/Launcher.cpp
@@ -126,6 +126,7 @@ void Launcher::resolveParams(Archi */*archi*/, SRDAGGraph *topDag) {
         Param *parameters = CREATE_MUL(TRANSFO_STACK, curNParam_, Param);
         int counter = 0;
     #endif
+    std::map<const char*, Param> dynamicParamsMap;
         
     while (curNParam_) {
         NotificationMessage message;
@@ -151,6 +152,9 @@ void Launcher::resolveParams(Archi */*archi*/, SRDAGGraph *topDag) {
                             counter++;
                         }
                     #endif
+                    if(Spider::getEnergyAwareness()){
+                        dynamicParamsMap.insert(std::make_pair(referenceParameter->getName(), referenceParameter->getValue()));
+                    }
                     if (Spider::getVerbose()) {
                         auto *parameterName = vertex->getReference()->getOutParam(i)->getName();
                         Logger::print(LOG_GENERAL, LOG_INFO, "Received Parameter: %s -- Value: %" PRId64"\n",
@@ -173,6 +177,9 @@ void Launcher::resolveParams(Archi */*archi*/, SRDAGGraph *topDag) {
         }
         StackMonitor::free(TRANSFO_STACK, parameters);
     #endif
+    if(Spider::getEnergyAwareness()){
+        Spider::setNewDynamicParamsEnergyAwareness(dynamicParamsMap);
+    }
 }
 
 void Launcher::sendTraceSpider(TraceSpiderType type, Time start, Time end) {

--- a/master/libspider/spider/launcher/Launcher.cpp
+++ b/master/libspider/spider/launcher/Launcher.cpp
@@ -43,6 +43,8 @@
 #include <Logger.h>
 #include "Launcher.h"
 
+#include "energyAwareness/energyAwareness.h"
+
 #ifdef APOLLO_AVAILABLE
 
 #include <apolloAPI.h>
@@ -178,7 +180,7 @@ void Launcher::resolveParams(Archi */*archi*/, SRDAGGraph *topDag) {
         StackMonitor::free(TRANSFO_STACK, parameters);
     #endif
     if(Spider::getEnergyAwareness()){
-        Spider::setNewDynamicParamsEnergyAwareness(dynamicParamsMap);
+        EnergyAwareness::setNewDynamicParams(dynamicParamsMap);
     }
 }
 

--- a/master/libspider/spider/spider.cpp
+++ b/master/libspider/spider/spider.cpp
@@ -197,6 +197,24 @@ void Spider::iterate() {
     }
     /** Wait for LRTs to finish **/
     Platform::get()->rstJobIxRecv();
+
+    /** Compute energy **/
+    if(energyAwareness_){
+        printf("Computing energy for this iteration\n");
+        double energyTotal = 0.0;
+        // Fill the list_ with SRDAGVertices in scheduling order
+        for (int i = 0; i < srdag_->getNVertex(); i++) {
+            SRDAGVertex *vertex = srdag_->getVertex(i);
+            if(vertex->getType() == SRDAG_NORMAL){
+                int peType = vertex->getScheduleJob()->getMappedPE();
+                int pe = archi_->getPEFromSpiderID(peType)->getHardwareType();
+                auto piVertex = vertex->getReference();
+                double energy = piVertex->getEnergyOnPEType(pe);
+                energyTotal = energyTotal + energy;      
+            }
+        }
+        printf("Energy consumption of this iteration = %f\n", energyTotal);
+    }
 }
 
 

--- a/master/libspider/spider/spider.cpp
+++ b/master/libspider/spider/spider.cpp
@@ -106,7 +106,6 @@ static bool apolloCompiled_;
 // energy awareness info
 static bool energyAwareness_;
 static double performanceObjective_;
-static double performanceTolerance_;
 static Time startingExecutionTime_;
 static Time endingExecutionTime_;
 
@@ -172,7 +171,6 @@ void Spider::init(SpiderConfig &cfg, SpiderStackConfig &stackConfig) {
     setEnergyAwareness(cfg.energyAwareness);
     if(energyAwareness_){
         setPerformanceObjective(cfg.performanceObjective);
-        setPerformanceTolerance(cfg.performanceTolerance);
         Spider::setUpEnergyAwareness();
         pesBeingDisabled_ = 0;
         pesBestConfig_ = -1;
@@ -322,15 +320,13 @@ void Spider::setUpEnergyAwareness() {
 }
 
 void Spider::checkExecutionPerformance(double fpsEstimation, double energyConsumed) {
-    double maxObjective = performanceObjective_ + performanceObjective_ * performanceTolerance_ / 100;
-    double minObjective = performanceObjective_ - performanceObjective_ * performanceTolerance_ / 100;
-    if (fpsEstimation <= maxObjective && fpsEstimation >= minObjective) {
+    if (fpsEstimation >= performanceObjective_) {
         if (bestEnergy_ > energyConsumed) {
             bestEnergy_ = energyConsumed;
             bestObjective_ = fpsEstimation;
             pesBestConfig_ = pesBeingDisabled_;
         } 
-    }else if (fabs(performanceObjective_ - fpsEstimation) < fabs(performanceObjective_ - bestObjective_)) {
+    }else if (fpsEstimation > bestObjective_ && bestEnergy_ == std::numeric_limits<double>::max()) {
         bestObjective_ = fpsEstimation;
         pesBestConfig_ = pesBeingDisabled_;
     }
@@ -474,10 +470,6 @@ void Spider::setEnergyAwareness(bool energyAwareness) {
 
 void Spider::setPerformanceObjective(double performanceObjective) {
     performanceObjective_ = performanceObjective;
-}
-
-void Spider::setPerformanceTolerance(double performanceTolerance) {
-    performanceTolerance_ = performanceTolerance;
 }
 
 void Spider::setApolloEnabled(bool apolloEnabled) {

--- a/master/libspider/spider/spider.cpp
+++ b/master/libspider/spider/spider.cpp
@@ -350,6 +350,10 @@ void Spider::checkExecutionPerformance(double fpsEstimation, double energyConsum
 }
 
 bool Spider::generateNextEnergyConfiguration() {
+    return generateNextFineGrainEnergyConfiguration();
+}
+
+bool Spider::generateNextFineGrainEnergyConfiguration(){
     bool alreadyUsingTheMaximum = true;
     for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
         if(aboveBelowObjective_){ // As we are modifying the number of disabled PEs, we have to increase the disable PEs when we are above the number

--- a/master/libspider/spider/spider.cpp
+++ b/master/libspider/spider/spider.cpp
@@ -73,6 +73,9 @@
 #include <limits>
 #include <math.h>
 
+// energyAwareness
+#include <energyAwareness/energyAwareness.h>
+
 // #ifndef __k1__
 // #include <HAL/hal/hal_ext.h>
 // #endif
@@ -106,37 +109,11 @@ static bool apolloCompiled_;
 // energy awareness info
 static bool energyAwareness_;
 static double performanceObjective_;
-static Time startingExecutionTime_;
-static Time endingExecutionTime_;
-
-static std::map<std::uint32_t, std::vector<std::uint32_t>> peIdPerPeType_; 
-static std::map<std::uint32_t, std::uint32_t> pesBeingDisabled_; 
-
-static std::map<const char*, Param> dynamicParameters_;
-static std::uint32_t numDynamicParameters_;
-static std::vector<std::map<std::uint32_t, std::uint32_t>> configsAlreadyUsed_; 
-static std::map<std::uint32_t, std::uint32_t> pesBestConfig_; 
-static double bestEnergy_;
-static double bestObjective_;
-static bool energyAlreadyOptimized_;
-static bool solutionShown_;
-static bool aboveBelowObjective_; // 1 current config is above objective -- 0 current config is below objective
-static std::uint32_t timesObjectiveMissed_; // Fail safe when not reaching the objective
-static bool forcedUpdate_; // True when the performance of the best config does not reach the objective 10 times in a row
-
-static std::map<std::map<const char*, Param>, std::vector<std::map<std::uint32_t, std::uint32_t>>> configsAlreadyUsedBackup_; 
-static std::map<std::map<const char*, Param>, std::map<std::uint32_t, std::uint32_t>> pesBestConfigBackup_; 
-static std::map<std::map<const char*, Param>, std::map<std::uint32_t, std::uint32_t>> pesBeingDisabledBackup_; 
-static std::map<std::map<const char*, Param>, double> bestEnergyBackup_; 
-static std::map<std::map<const char*, Param>, double> bestObjectiveBackup_; 
-static std::map<std::map<const char*, Param>, bool> energyAlreadyOptimizedBackup_; 
-static std::map<std::map<const char*, Param>, bool> aboveBelowObjectiveBackup_; 
 
 static bool containsDynamicParam(PiSDFGraph *const graph) {
     for (int i = 0; i < graph->getNParam(); ++i) {
         auto *param = graph->getParam(i);
         if (param->isDynamic()) {
-            numDynamicParameters_ = numDynamicParameters_ + 1;
             return true;
         }
     }
@@ -185,14 +162,7 @@ void Spider::init(SpiderConfig &cfg, SpiderStackConfig &stackConfig) {
     setEnergyAwareness(cfg.energyAwareness);
     if(energyAwareness_){
         setPerformanceObjective(cfg.performanceObjective);
-        Spider::setUpEnergyAwareness();
-        energyAlreadyOptimized_ = false;
-        solutionShown_ = false;
-        bestEnergy_ = std::numeric_limits<double>::max();
-        bestObjective_ = 0.0;
-        numDynamicParameters_ = 0;
-        timesObjectiveMissed_ = 0;
-        forcedUpdate_ = false;
+        EnergyAwareness::setUp(archi_);
     }
 
     if (traceEnabled_) {
@@ -214,9 +184,9 @@ void Spider::iterate() {
     // The behavior when using energy awareness is slightly different
     if (pisdf_->isGraphStatic()) {
         if(energyAwareness_){
-            if(energyAlreadyOptimized_){
+            if(EnergyAwareness::getEnergyAlreadyOptimized()){
                 if(!srdag_){
-                    energyAwarenessApplyConfig();
+                    EnergyAwareness::applyConfig(archi_);
                     /* On final iteration, the schedule is created */
                     srdag_ = new SRDAGGraph();
                     schedule_ = static_scheduler(srdag_, memAlloc_, scheduler_);
@@ -236,9 +206,9 @@ void Spider::iterate() {
             }
         }
         /* Run the schedule */
-        Spider::setStartingTime();
+        EnergyAwareness::setStartingTime();
         schedule_->executeAndRun();
-        Spider::setEndTime();
+        EnergyAwareness::setEndTime();
         schedule_->restartSchedule();
     } else {
         delete srdag_;
@@ -258,195 +228,8 @@ void Spider::iterate() {
 
     /** Compute energy **/
     if(energyAwareness_){
-        energyAwarenessAnalyzeExecution();
-        energyAwarenessPrepareNextExecution();
-    }
-}
-
-void Spider::setStartingTime() {
-    startingExecutionTime_ = Platform::get()->getTime();
-}
-
-void Spider::setEndTime() {
-    endingExecutionTime_ = Platform::get()->getTime();
-}
-
-unsigned long Spider::getExecutionTime() {
-    return (endingExecutionTime_ - startingExecutionTime_) / CHIP_FREQ;
-}
-
-double Spider::computeEnergy(SRDAGGraph *srdag, Archi *archi, double fpsEstimation) {
-    double energyIter = 0.0;
-    std::vector<std::uint32_t> pesUsed;
-    for (int i = 0; i < srdag->getNVertex(); i++) {
-        SRDAGVertex *vertex = srdag->getVertex(i);
-        if (vertex->getType() == SRDAG_NORMAL) {
-            int peUsed = vertex->getScheduleJob()->getMappedPE();
-            int peType = archi_->getPEFromSpiderID(peUsed)->getHardwareType();
-            auto piVertex = vertex->getReference();
-            double energy = piVertex->getEnergyOnPEType(peType);
-            energyIter = energyIter + energy;      
-        }
-    }
-    // we asume that energy for each actor is given in uJ
-    double energyApp = (energyIter / (1000.0 * 1000.0))  * fpsEstimation;
-    // as power is provided in W and we want energy per second, values are equivalent
-    double energyPlatform = archi_->getBasePower();
-    for (unsigned int i = 0; i < archi->getNPE(); i++) {
-        auto pe = archi->getPEFromSpiderID(i);
-        if (pe->isEnabled()) {
-            energyPlatform = energyPlatform + pe->getPower();            
-        }
-    }
-    return energyApp + energyPlatform;    
-}
-
-double Spider::computeFps() {
-    unsigned long execTime = Spider::getExecutionTime();
-    // execution time is given in ns
-    return (1000.0 * 1000.0 * 1000.0) / (double) execTime;
-}
-
-void Spider::setUpEnergyAwareness() {
-    auto spiderId = archi_->getSpiderGRTID();
-    for (std::uint32_t i = 0; i < archi_->getNPE(); i++) {
-        auto pe = archi_->getPEFromSpiderID(i);
-        if (i != spiderId) {
-            auto peType = pe->getHardwareType();
-            auto it = peIdPerPeType_.find(peType);
-            if (it != peIdPerPeType_.end()) {
-                it->second.push_back(i);
-            } else {
-                std::vector<std::uint32_t> peIdSet;
-                peIdSet.push_back(i);
-                peIdPerPeType_.insert(std::make_pair(peType, peIdSet));
-            }          
-        }
-    }
-    for (auto it = peIdPerPeType_.begin(); it != peIdPerPeType_.end(); it++) {
-        pesBeingDisabled_.insert(std::make_pair(it->first, 0));
-        pesBestConfig_.insert(std::make_pair(it->first, 0));
-    }
-}
-
-void Spider::checkExecutionPerformance(double fpsEstimation, double energyConsumed) {
-    aboveBelowObjective_ = false;
-    if (fpsEstimation >= performanceObjective_) {
-        aboveBelowObjective_ = true;
-        if (bestEnergy_ > energyConsumed || forcedUpdate_) {
-            bestEnergy_ = energyConsumed;
-            bestObjective_ = fpsEstimation;
-            for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
-                pesBestConfig_[it->first] = it->second;
-            }
-        } 
-    }else if (fpsEstimation > bestObjective_ && bestEnergy_ == std::numeric_limits<double>::max()) {
-        bestObjective_ = fpsEstimation;
-        for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
-            pesBestConfig_[it->first] = it->second;
-        }
-    }
-    forcedUpdate_ = false;
-}
-
-bool Spider::generateNextEnergyConfiguration() {
-    return generateNextFineGrainEnergyConfiguration();
-}
-
-bool Spider::generateNextFineGrainEnergyConfiguration(){
-    bool alreadyUsingTheMaximum = true;
-    for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
-        if(aboveBelowObjective_){ // As we are modifying the number of disabled PEs, we have to increase the disable PEs when we are above the number
-            if(pesBeingDisabled_[it->first] == peIdPerPeType_[it->first].size()){
-                pesBeingDisabled_[it->first] = 0;
-            }else{
-                pesBeingDisabled_[it->first] = pesBeingDisabled_[it->first] + 1; 
-                break;
-            }      
-        } else {
-            if(pesBeingDisabled_[it->first] == 0){
-                pesBeingDisabled_[it->first] = peIdPerPeType_[it->first].size();
-            }else{
-                pesBeingDisabled_[it->first] = pesBeingDisabled_[it->first] - 1;  
-                alreadyUsingTheMaximum = false;
-                break;
-            }      
-        }
-    }
-    auto it = std::find(configsAlreadyUsed_.begin(), configsAlreadyUsed_.end(), pesBeingDisabled_);
-    if (it == configsAlreadyUsed_.end()) {
-        return true;
-    } else if(!aboveBelowObjective_ && bestEnergy_ != std::numeric_limits<double>::max() && !alreadyUsingTheMaximum){
-        timesObjectiveMissed_++;
-        if(timesObjectiveMissed_ == 10){
-            timesObjectiveMissed_ = 0;
-            forcedUpdate_ = true;
-            printf("Increasing number of enabled PEs because the objective has been missed 10 times\n");
-            return true;
-        }
-    }
-    return false;
-}
-
-void Spider::energyAwarenessApplyConfig(){
-    auto it = std::find(configsAlreadyUsed_.begin(), configsAlreadyUsed_.end(), pesBeingDisabled_);
-    if (it == configsAlreadyUsed_.end()) {
-        configsAlreadyUsed_.push_back(pesBeingDisabled_);
-    }
-    std::map<std::uint32_t, std::uint32_t> pesAlreadyDisbled;
-    for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
-        pesAlreadyDisbled.insert(std::make_pair(it->first, 0));
-    }
-    for(auto it = peIdPerPeType_.begin(); it != peIdPerPeType_.end(); it++){
-        for(auto itInner = it->second.begin(); itInner != it->second.end(); itInner++){
-            archi_->activatePE(archi_->getPEFromSpiderID(*itInner));
-        }
-    }
-    for(auto it = peIdPerPeType_.begin(); it != peIdPerPeType_.end(); it++){
-        for(auto itInner = it->second.begin(); itInner != it->second.end(); itInner++){
-            if(pesAlreadyDisbled[it->first] == pesBeingDisabled_[it->first]){
-                break;
-            }
-            archi_->deactivatePE(archi_->getPEFromSpiderID(*itInner));
-            pesAlreadyDisbled[it->first] = pesAlreadyDisbled[it->first] + 1;
-        }
-    }
-}
-
-void Spider::energyAwarenessAnalyzeExecution(){
-    double fpsEstimation = computeFps();
-    double energyConsumed = computeEnergy(srdag_, archi_, fpsEstimation);
-
-    checkExecutionPerformance(fpsEstimation, energyConsumed);
-}
-
-void Spider::energyAwarenessPrepareNextExecution(){
-    if(!generateNextEnergyConfiguration()){
-        energyAlreadyOptimized_ = true;
-        pesBeingDisabled_ = pesBestConfig_;
-        for (auto it = pesBestConfig_.begin(); it != pesBestConfig_.end(); it++) {
-            pesBeingDisabled_[it->first] = it->second;
-        }
-        if(!solutionShown_){
-            solutionShown_ = true;
-            std::uint32_t totalCoresUsed = 0;
-            for (auto it = pesBestConfig_.begin(); it != pesBestConfig_.end(); it++) {
-                totalCoresUsed = totalCoresUsed + peIdPerPeType_[it->first].size() - it->second;
-            }
-            if(bestEnergy_ == std::numeric_limits<double>::max()){
-                printf("Best FPS %f. Objective not reachable --> ", bestObjective_);    
-                printf("Closer one reached using %d cores", (totalCoresUsed + 1)); // We include here the GRT
-            }else{
-                printf("Best FPS %f and best energy consumed = %f ---> ", bestObjective_, bestEnergy_);   
-                printf("Reached using %d cores", (totalCoresUsed + 1)); // We include here the GRT             
-            }
-            printf("\n");
-            printf("Using config (PEType: disabled/total): ");
-            for (auto it = pesBestConfig_.begin(); it != pesBestConfig_.end(); it++) {
-                printf("%d: %d/%lu --- ", it->first, it->second, peIdPerPeType_[it->first].size());
-            }
-            printf("\n");
-        }
+        EnergyAwareness::analyzeExecution(srdag_, archi_);
+        EnergyAwareness::prepareNextExecution();
     }
 }
 
@@ -454,59 +237,8 @@ bool Spider::getEnergyAwareness() {
     return energyAwareness_;
 }
 
-void Spider::recoverEnergyAwarenessOrDefault() {
-    timesObjectiveMissed_ = 0;
-    // All the energy-awareness related variables are stored at the same time
-    // So we only check one and we consider that everything is properly done
-    auto itCheckerEnergyAlreadyOptimized = energyAlreadyOptimizedBackup_.find(dynamicParameters_);
-    if(itCheckerEnergyAlreadyOptimized != energyAlreadyOptimizedBackup_.end()){
-        energyAlreadyOptimized_ = energyAlreadyOptimizedBackup_[dynamicParameters_];
-        aboveBelowObjective_ = aboveBelowObjectiveBackup_[dynamicParameters_];
-        pesBestConfig_ = pesBestConfigBackup_[dynamicParameters_];
-        pesBeingDisabled_ = pesBeingDisabledBackup_[dynamicParameters_]; 
-        bestEnergy_ = bestEnergyBackup_[dynamicParameters_];
-        bestObjective_ = bestObjectiveBackup_[dynamicParameters_];
-        configsAlreadyUsed_ = configsAlreadyUsedBackup_[dynamicParameters_];
-    }else{
-        energyAlreadyOptimized_ = false;        
-        for (auto it = pesBeingDisabled_.begin(); it != pesBeingDisabled_.end(); it++) {
-            pesBestConfig_[it->first] = it->second;
-        }
-        bestEnergy_ = std::numeric_limits<double>::max();
-        bestObjective_ = 0.0;
-        configsAlreadyUsed_.clear();
-    }
-    solutionShown_ = false;
-}
-
-void Spider::setNewDynamicParamsEnergyAwareness(std::map<const char*, Param> dynamicParamsMap) {
-    //Store current best ones
-    configsAlreadyUsedBackup_[dynamicParameters_] = configsAlreadyUsed_; 
-    pesBestConfigBackup_[dynamicParameters_] = pesBestConfig_; 
-    pesBeingDisabledBackup_[dynamicParameters_] = pesBeingDisabled_; 
-    bestEnergyBackup_[dynamicParameters_] = bestEnergy_; 
-    bestObjectiveBackup_[dynamicParameters_] = bestObjective_; 
-    energyAlreadyOptimizedBackup_[dynamicParameters_] = energyAlreadyOptimized_;
-    aboveBelowObjectiveBackup_[dynamicParameters_] = aboveBelowObjective_;
-
-    //Check the need to update the config
-    bool dirtyEnergyConfig = false;
-    for (auto it = dynamicParamsMap.begin(); it != dynamicParamsMap.end(); it++) {
-        auto itChecker = dynamicParameters_.find(it->first);
-        if(itChecker == dynamicParameters_.end()){
-            dynamicParameters_.insert(std::make_pair(it->first, it->second));
-            dirtyEnergyConfig = true;
-        } else {
-            if(dynamicParameters_[it->first] != it->second){
-                dirtyEnergyConfig = true;
-                dynamicParameters_[it->first] = it->second;
-            }
-        }        
-    }
-    //Update config if needed
-    if(dirtyEnergyConfig){
-        recoverEnergyAwarenessOrDefault();
-    }
+double Spider::getPerformanceObjective() {
+    return performanceObjective_;
 }
 
 static int getReservedMemoryForGraph(PiSDFGraph *graph, int currentMemReserved) {

--- a/master/libspider/spider/spider.cpp
+++ b/master/libspider/spider/spider.cpp
@@ -101,6 +101,11 @@ static bool papifyFeedbackEnabled_;
 static bool apolloEnabled_;
 static bool apolloCompiled_;
 
+// energy awareness info
+static bool energyAwareness_;
+static bool performanceObjective_;
+static bool performanceTolerance_;
+
 static bool containsDynamicParam(PiSDFGraph *const graph) {
     for (int i = 0; i < graph->getNParam(); ++i) {
         auto *param = graph->getParam(i);
@@ -148,6 +153,12 @@ void Spider::init(SpiderConfig &cfg, SpiderStackConfig &stackConfig) {
     platform_ = new PlatformPThread(cfg, stackConfig);
 
     setPapifyFeedbackEnabled(cfg.feedbackPapifyInfo);
+
+    setEnergyAwareness(cfg.energyAwareness);
+    if(energyAwareness_){
+        setPerformanceObjective(cfg.performanceObjective);
+        setPerformanceTolerance(cfg.performanceTolerance);
+    }
 
     if (traceEnabled_) {
         Launcher::get()->sendEnableTrace(-1);
@@ -307,6 +318,18 @@ void Spider::setTraceEnabled(bool traceEnabled) {
 
 void Spider::setPapifyFeedbackEnabled(bool papifyFeedbackEnabled) {
     papifyFeedbackEnabled_ = papifyFeedbackEnabled;
+}
+
+void Spider::setEnergyAwareness(bool energyAwareness) {
+    energyAwareness_ = energyAwareness;
+}
+
+void Spider::setPerformanceObjective(double performanceObjective) {
+    performanceObjective_ = performanceObjective;
+}
+
+void Spider::setPerformanceTolerance(double performanceTolerance) {
+    performanceTolerance_ = performanceTolerance;
 }
 
 void Spider::setApolloEnabled(bool apolloEnabled) {

--- a/master/libspider/spider/spider.cpp
+++ b/master/libspider/spider/spider.cpp
@@ -200,21 +200,23 @@ void Spider::iterate() {
 
     /** Compute energy **/
     if(energyAwareness_){
-        printf("Computing energy for this iteration\n");
-        double energyTotal = 0.0;
-        // Fill the list_ with SRDAGVertices in scheduling order
-        for (int i = 0; i < srdag_->getNVertex(); i++) {
-            SRDAGVertex *vertex = srdag_->getVertex(i);
-            if(vertex->getType() == SRDAG_NORMAL){
-                int peType = vertex->getScheduleJob()->getMappedPE();
-                int pe = archi_->getPEFromSpiderID(peType)->getHardwareType();
-                auto piVertex = vertex->getReference();
-                double energy = piVertex->getEnergyOnPEType(pe);
-                energyTotal = energyTotal + energy;      
-            }
-        }
-        printf("Energy consumption of this iteration = %f\n", energyTotal);
+        double energyConsumed = computeEnergy(srdag_);
     }
+}
+
+double Spider::computeEnergy(SRDAGGraph *srdag){
+    double energyTotal = 0.0;
+    for (int i = 0; i < srdag->getNVertex(); i++) {
+        SRDAGVertex *vertex = srdag->getVertex(i);
+        if(vertex->getType() == SRDAG_NORMAL){
+            int peType = vertex->getScheduleJob()->getMappedPE();
+            int pe = archi_->getPEFromSpiderID(peType)->getHardwareType();
+            auto piVertex = vertex->getReference();
+            double energy = piVertex->getEnergyOnPEType(pe);
+            energyTotal = energyTotal + energy;      
+        }
+    }
+    return energyTotal;    
 }
 
 

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -134,6 +134,9 @@ typedef struct SpiderConfig {
 
     std::map<lrtFct, std::map<const char *, PapifyConfig*>> papifyJobInfo;
     std::map<lrtFct, std::map<const char *, std::map<int, double>>> energyModelsInfo;
+    bool energyAwareness;
+    double performanceObjective;
+    double performanceTolerance;
 
     lrtFct *fcts;
     int nLrtFcts;
@@ -193,6 +196,12 @@ namespace Spider {
     void setTraceEnabled(bool traceEnabled);
 
     void setPapifyFeedbackEnabled(bool papifyFeedbackEnabled);
+
+    void setEnergyAwareness(bool energyAwareness);
+
+    void setPerformanceObjective(double performanceObjective);
+
+    void setPerformanceTolerance(double performanceTolerance);
 
     void setApolloEnabled(bool apolloEnabled);
 

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -240,7 +240,9 @@ namespace Spider {
 
     Archi *getArchi();
 
-    double computeEnergy(SRDAGGraph *srdag, Archi *archi);
+    double computeEnergy(SRDAGGraph *srdag, Archi *archi, double fpsEstimation);
+
+    double computeFps();
 
     void setStartingTime();
 
@@ -249,6 +251,10 @@ namespace Spider {
     unsigned long getExecutionTime();
 
     void setUpEnergyAwareness();
+
+    void checkExecutionPerformance(double fpsEstimation, double energyConsumed);
+
+    bool generateNextEnergyConfiguration();
 }
 
 #endif//SPIDER_H

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -239,6 +239,8 @@ namespace Spider {
     PiSDFGraph *getGraph();
 
     Archi *getArchi();
+
+    double computeEnergy(SRDAGGraph *srdag);
 }
 
 #endif//SPIDER_H

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -266,6 +266,8 @@ namespace Spider {
     void recoverEnergyAwarenessOrDefault();
 
     void setNewDynamicParamsEnergyAwareness(std::map<const char*, Param> dynamicParamsMap);
+
+    bool generateNextFineGrainEnergyConfiguration();
 }
 
 #endif//SPIDER_H

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -237,6 +237,10 @@ namespace Spider {
 
     Archi *getArchi();
 
+    // Energy-awareness functions
+
+    bool getEnergyAwareness();
+
     double computeEnergy(SRDAGGraph *srdag, Archi *archi, double fpsEstimation);
 
     double computeFps();
@@ -252,6 +256,16 @@ namespace Spider {
     void checkExecutionPerformance(double fpsEstimation, double energyConsumed);
 
     bool generateNextEnergyConfiguration();
+
+    void energyAwarenessApplyConfig();
+
+    void energyAwarenessAnalyzeExecution();
+
+    void energyAwarenessPrepareNextExecution();
+
+    void recoverEnergyAwarenessOrDefault();
+
+    void setNewDynamicParamsEnergyAwareness(std::map<const char*, Param> dynamicParamsMap);
 }
 
 #endif//SPIDER_H

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -237,37 +237,9 @@ namespace Spider {
 
     Archi *getArchi();
 
-    // Energy-awareness functions
-
     bool getEnergyAwareness();
 
-    double computeEnergy(SRDAGGraph *srdag, Archi *archi, double fpsEstimation);
-
-    double computeFps();
-
-    void setStartingTime();
-
-    void setEndTime();
-
-    unsigned long getExecutionTime();
-
-    void setUpEnergyAwareness();
-
-    void checkExecutionPerformance(double fpsEstimation, double energyConsumed);
-
-    bool generateNextEnergyConfiguration();
-
-    void energyAwarenessApplyConfig();
-
-    void energyAwarenessAnalyzeExecution();
-
-    void energyAwarenessPrepareNextExecution();
-
-    void recoverEnergyAwarenessOrDefault();
-
-    void setNewDynamicParamsEnergyAwareness(std::map<const char*, Param> dynamicParamsMap);
-
-    bool generateNextFineGrainEnergyConfiguration();
+    double getPerformanceObjective();
 }
 
 #endif//SPIDER_H

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -240,7 +240,15 @@ namespace Spider {
 
     Archi *getArchi();
 
-    double computeEnergy(SRDAGGraph *srdag);
+    double computeEnergy(SRDAGGraph *srdag, Archi *archi);
+
+    void setStartingTime();
+
+    void setEndTime();
+
+    unsigned long getExecutionTime();
+
+    void setUpEnergyAwareness();
 }
 
 #endif//SPIDER_H

--- a/master/libspider/spider/spider.h
+++ b/master/libspider/spider/spider.h
@@ -136,7 +136,6 @@ typedef struct SpiderConfig {
     std::map<lrtFct, std::map<const char *, std::map<int, double>>> energyModelsInfo;
     bool energyAwareness;
     double performanceObjective;
-    double performanceTolerance;
 
     lrtFct *fcts;
     int nLrtFcts;
@@ -200,8 +199,6 @@ namespace Spider {
     void setEnergyAwareness(bool energyAwareness);
 
     void setPerformanceObjective(double performanceObjective);
-
-    void setPerformanceTolerance(double performanceTolerance);
 
     void setApolloEnabled(bool apolloEnabled);
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,6 +5,10 @@ Spider Changelog
 *XXXX.XX.XX*
 
 ### New Feature
+* Energy awareness (energy-awareness parameter) now can be activated in SPiDER
+  * It will test a different number of PEs in each iteration
+  * It will keep the PE config reaching the objective with the lowest (estimated) energy consumption
+  * In the case of static apps, the searching will be done with the dynamic structure and, after the selection, everything will follow the standard flow. This avoids memory leakages
 
 ### Changes
 


### PR DESCRIPTION
Energy awareness (energy-awareness parameter) now can be activated in 
- It will test a different number of PEs in each 
- It will keep the PE config reaching the objective with the lowest (estimated) energy 
- In the case of static apps, the searching will be done with the dynamic structure and, after the selection, everything will follow the standard flow. This avoids memory leakages